### PR TITLE
Add skeleton for course + course instances pages

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,5 +23,6 @@ module.exports = {
       },
     ],
     'react-hooks/rules-of-hooks': 'error',
+    'no-underscore-dangle': ['off'],
   },
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/nwalters512/attendance#readme",
   "dependencies": {
+    "body-parser": "^1.18.3",
     "ejs": "^2.6.1",
     "express": "^4.16.4",
     "winston": "^3.2.1"

--- a/src/pages/course/course.ejs
+++ b/src/pages/course/course.ejs
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <%- include('../partials/head') %>
+  </head>
+  <body>
+    <%- include('../partials/header') %>
+    <div class="container">
+      <h1>Course <%= courseId %></h1>
+      <h2>Sections</h2>
+      <button
+        role="button"
+        class="btn btn-primary mb-3"
+        data-toggle="collapse"
+        data-target="#newSection"
+        role="button"
+        aria-expanded="false"
+        aria-controls="newSection"
+      >
+        New Section
+      </button>
+      <div class="collapse" id="newSection">
+        <div class="card card-body mb-3">
+          <form method="POST">
+            <input type="hidden" name="__action" value="newSection">
+            <div class="form-group">
+              <label for="sectionName">Name</label>
+              <input class="form-control" name="name" id="sectionName">
+            </div>
+            <button type="submit" class="btn btn-primary">Create section</button>
+          </form>
+        </div>
+      </div>
+      <ul class="list-group mb-4">
+        <% sections.forEach(function(section) { %>
+        <li class="list-group-item"><%= section.name %></li>
+        <% }) %>
+      </ul>
+      <h2>Meetings</h2>
+      <button
+        role="button"
+        class="btn btn-primary mb-3"
+        data-toggle="collapse"
+        data-target="#newMeeting"
+        role="button"
+        aria-expanded="false"
+        aria-controls="newMeeting"
+      >
+        New Meeting
+      </button>
+      <div class="collapse" id="newMeeting">
+        <div class="card card-body mb-3">
+          <form method="POST">
+            <input type="hidden" name="__action" value="newMeeting">
+            <div class="form-group">
+              <label for="meetingName">Name</label>
+              <input class="form-control" name="name" id="meetingName">
+            </div>
+            <button type="submit" class="btn btn-primary">Create meeting</button>
+          </form>
+        </div>
+      </div>
+      <ul class="list-group mb-4">
+        <% meetings.forEach(function(meeting) { %>
+        <li class="list-group-item"><%= meeting.name %></li>
+        <% }) %>
+      </ul>
+    </div>
+  </body>
+</html>

--- a/src/pages/course/course.ejs
+++ b/src/pages/course/course.ejs
@@ -7,63 +7,9 @@
     <%- include('../partials/header') %>
     <div class="container">
       <h1>Course <%= courseId %></h1>
-      <h2>Sections</h2>
-      <button
-        role="button"
-        class="btn btn-primary mb-3"
-        data-toggle="collapse"
-        data-target="#newSection"
-        role="button"
-        aria-expanded="false"
-        aria-controls="newSection"
-      >
-        New Section
-      </button>
-      <div class="collapse" id="newSection">
-        <div class="card card-body mb-3">
-          <form method="POST">
-            <input type="hidden" name="__action" value="newSection">
-            <div class="form-group">
-              <label for="sectionName">Name</label>
-              <input class="form-control" name="name" id="sectionName">
-            </div>
-            <button type="submit" class="btn btn-primary">Create section</button>
-          </form>
-        </div>
-      </div>
-      <ul class="list-group mb-4">
-        <% sections.forEach(function(section) { %>
-        <li class="list-group-item"><%= section.name %></li>
-        <% }) %>
-      </ul>
-      <h2>Meetings</h2>
-      <button
-        role="button"
-        class="btn btn-primary mb-3"
-        data-toggle="collapse"
-        data-target="#newMeeting"
-        role="button"
-        aria-expanded="false"
-        aria-controls="newMeeting"
-      >
-        New Meeting
-      </button>
-      <div class="collapse" id="newMeeting">
-        <div class="card card-body mb-3">
-          <form method="POST">
-            <input type="hidden" name="__action" value="newMeeting">
-            <div class="form-group">
-              <label for="meetingName">Name</label>
-              <input class="form-control" name="name" id="meetingName">
-            </div>
-            <button type="submit" class="btn btn-primary">Create meeting</button>
-          </form>
-        </div>
-      </div>
-      <ul class="list-group mb-4">
-        <% meetings.forEach(function(meeting) { %>
-        <li class="list-group-item"><%= meeting.name %></li>
-        <% }) %>
+      <h2>Course Instances</h2>
+      <ul class="list-group">
+        <li class="list-group-item">I am an instance</li>
       </ul>
     </div>
   </body>

--- a/src/pages/course/course.js
+++ b/src/pages/course/course.js
@@ -1,43 +1,8 @@
-const router = require('express').Router()
+const router = require('express').Router({ mergeParams: true })
 
-const sections = [
-  {
-    name: 'Hello!',
-  },
-  {
-    name: 'World!',
-  },
-]
-
-const meetings = [
-  {
-    name: 'Goodbye!',
-  },
-  {
-    name: 'World!',
-  },
-]
-
-router.get('/:courseId', (req, res, next) => {
+router.get('/', (req, res, next) => {
   res.locals.courseId = req.params.courseId
-  res.locals.sections = sections
-  res.locals.meetings = meetings
   res.render(__filename.replace(/\.js/, '.ejs'), res.locals)
-})
-
-router.post('/:courseId', (req, res, next) => {
-  if (req.body.__action === 'newSection') {
-    const section = {
-      name: req.body.name,
-    }
-    sections.push(section)
-  } else if (req.body.__action === 'newMeeting') {
-    const meeting = {
-      name: req.body.name,
-    }
-    meetings.push(meeting)
-  }
-  res.redirect(req.originalUrl)
 })
 
 module.exports = router

--- a/src/pages/course/course.js
+++ b/src/pages/course/course.js
@@ -1,0 +1,43 @@
+const router = require('express').Router()
+
+const sections = [
+  {
+    name: 'Hello!',
+  },
+  {
+    name: 'World!',
+  },
+]
+
+const meetings = [
+  {
+    name: 'Goodbye!',
+  },
+  {
+    name: 'World!',
+  },
+]
+
+router.get('/:courseId', (req, res, next) => {
+  res.locals.courseId = req.params.courseId
+  res.locals.sections = sections
+  res.locals.meetings = meetings
+  res.render(__filename.replace(/\.js/, '.ejs'), res.locals)
+})
+
+router.post('/:courseId', (req, res, next) => {
+  if (req.body.__action === 'newSection') {
+    const section = {
+      name: req.body.name,
+    }
+    sections.push(section)
+  } else if (req.body.__action === 'newMeeting') {
+    const meeting = {
+      name: req.body.name,
+    }
+    meetings.push(meeting)
+  }
+  res.redirect(req.originalUrl)
+})
+
+module.exports = router

--- a/src/pages/courseInstance/courseInstance.ejs
+++ b/src/pages/courseInstance/courseInstance.ejs
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <%- include('../partials/head') %>
+  </head>
+  <body>
+    <%- include('../partials/header') %>
+    <div class="container">
+      <h1>Course <%= courseInstanceId %></h1>
+      <h2>Sections</h2>
+      <button
+        role="button"
+        class="btn btn-primary mb-3"
+        data-toggle="collapse"
+        data-target="#newSection"
+        role="button"
+        aria-expanded="false"
+        aria-controls="newSection"
+      >
+        New Section
+      </button>
+      <div class="collapse" id="newSection">
+        <div class="card card-body mb-3">
+          <form method="POST">
+            <input type="hidden" name="__action" value="newSection">
+            <div class="form-group">
+              <label for="sectionName">Name</label>
+              <input class="form-control" name="name" id="sectionName">
+            </div>
+            <button type="submit" class="btn btn-primary">Create section</button>
+          </form>
+        </div>
+      </div>
+      <ul class="list-group mb-4">
+        <% sections.forEach(function(section) { %>
+        <li class="list-group-item"><%= section.name %></li>
+        <% }) %>
+      </ul>
+      <h2>Meetings</h2>
+      <button
+        role="button"
+        class="btn btn-primary mb-3"
+        data-toggle="collapse"
+        data-target="#newMeeting"
+        role="button"
+        aria-expanded="false"
+        aria-controls="newMeeting"
+      >
+        New Meeting
+      </button>
+      <div class="collapse" id="newMeeting">
+        <div class="card card-body mb-3">
+          <form method="POST">
+            <input type="hidden" name="__action" value="newMeeting">
+            <div class="form-group">
+              <label for="meetingName">Name</label>
+              <input class="form-control" name="name" id="meetingName">
+            </div>
+            <button type="submit" class="btn btn-primary">Create meeting</button>
+          </form>
+        </div>
+      </div>
+      <ul class="list-group mb-4">
+        <% meetings.forEach(function(meeting) { %>
+        <li class="list-group-item"><%= meeting.name %></li>
+        <% }) %>
+      </ul>
+    </div>
+  </body>
+</html>

--- a/src/pages/courseInstance/courseInstance.js
+++ b/src/pages/courseInstance/courseInstance.js
@@ -1,0 +1,43 @@
+const router = require('express').Router({ mergeParams: true })
+
+const sections = [
+  {
+    name: 'Hello!',
+  },
+  {
+    name: 'World!',
+  },
+]
+
+const meetings = [
+  {
+    name: 'Goodbye!',
+  },
+  {
+    name: 'World!',
+  },
+]
+
+router.get('/', (req, res, next) => {
+  res.locals.courseInstanceId = req.params.courseInstanceId
+  res.locals.sections = sections
+  res.locals.meetings = meetings
+  res.render(__filename.replace(/\.js/, '.ejs'), res.locals)
+})
+
+router.post('/', (req, res, next) => {
+  if (req.body.__action === 'newSection') {
+    const section = {
+      name: req.body.name,
+    }
+    sections.push(section)
+  } else if (req.body.__action === 'newMeeting') {
+    const meeting = {
+      name: req.body.name,
+    }
+    meetings.push(meeting)
+  }
+  res.redirect(req.originalUrl)
+})
+
+module.exports = router

--- a/src/pages/partials/head.ejs
+++ b/src/pages/partials/head.ejs
@@ -3,4 +3,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Attendance@Illinois</title>
 <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+<script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
 

--- a/src/server.js
+++ b/src/server.js
@@ -14,7 +14,11 @@ app.use(bodyParser.urlencoded({ extended: false, limit: 200 * 1024 }))
 app.use(bodyParser.json())
 
 app.use('/', require('./pages/home/home'))
-app.use('/course', require('./pages/course/course'))
+app.use('/course/:courseId', require('./pages/course/course'))
+app.use(
+  '/courseInstance/:courseInstanceId',
+  require('./pages/courseInstance/courseInstance')
+)
 
 const server = Server(app)
 server.listen(PORT)

--- a/src/server.js
+++ b/src/server.js
@@ -1,6 +1,8 @@
 const { Server } = require('http')
 const express = require('express')
 const path = require('path')
+const bodyParser = require('body-parser')
+
 const logger = require('./logger')
 
 const PORT = process.env.PORT || 3000
@@ -8,8 +10,11 @@ const PORT = process.env.PORT || 3000
 const app = express()
 app.set('views', path.join(__dirname, 'pages'))
 app.set('view engine', 'ejs')
+app.use(bodyParser.urlencoded({ extended: false, limit: 200 * 1024 }))
+app.use(bodyParser.json())
 
 app.use('/', require('./pages/home/home'))
+app.use('/course', require('./pages/course/course'))
 
 const server = Server(app)
 server.listen(PORT)


### PR DESCRIPTION
This creates skeleton pages for courses and course instances. Currently nothing is wired up to the DB, but it does allow rudimentary creation of sections and meetings that are held in-memory for testing purposes.

You can test these with `npm start` and then accessing `localhost:3000/course/1234` or `localhost:3000/courseInstance/1234`